### PR TITLE
Add variable to set color for active navbar arrow (fixes #1162)

### DIFF
--- a/sass/components/navbar.sass
+++ b/sass/components/navbar.sass
@@ -30,6 +30,7 @@ $navbar-dropdown-background-color: $scheme-main !default
 $navbar-dropdown-border-top: 2px solid $border !default
 $navbar-dropdown-offset: -4px !default
 $navbar-dropdown-arrow: $link !default
+$navbar-dropdown-active-arrow: $link !default
 $navbar-dropdown-radius: $radius-large !default
 $navbar-dropdown-z: 20 !default
 
@@ -220,6 +221,8 @@ a.navbar-item,
     border-color: $navbar-dropdown-arrow
     margin-top: -0.375em
     +ltr-position(1.125em)
+  &.is-active::after
+    border-color: $navbar-dropdown-active-arrow
 
 .navbar-dropdown
   font-size: 0.875rem


### PR DESCRIPTION
Introduce variable to customize the dropdown arrow's active face.

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is an **improvement**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

The dropdown arrow's face in of the navbar component can be customized via variable `$navbar-dropdown-arrow`. However there's no way to set its style when the nav link is active.

### Proposed solution

If nav link has `is-active`, use variable `$navbar-dropdown-active-arrow` to set the arrow's color.

There is a related, closed issue about the same problem: https://github.com/jgthms/bulma/issues/1162

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

None.

### Testing Done

I use it in my project and it works.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
